### PR TITLE
Update adaptive-wasm-loading.md

### DIFF
--- a/barcode-reader/web/capabilities/adaptive-wasm-loading.md
+++ b/barcode-reader/web/capabilities/adaptive-wasm-loading.md
@@ -54,7 +54,6 @@ However, developers can **manually override** this behavior and explicitly speci
 ```javascript
 Dynamsoft.Core.CoreModule.wasmLoadOptions = {
     wasmType: "ml-simd-pthread",
-    pthreadPoolSize: 5,
 };
 ```
 


### PR DESCRIPTION
Do not recommend that users configure the number of inference threads for DNN models themselves to avoid unexpected issues.