### PR TITLE
Exclude bare /faq/license/ path from sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -56,6 +56,15 @@ defaults:
     values:
       sitemap: false
   - scope:
+      # license/ is shared content, duplicated at build time under
+      # /faq/barcode-reader/license/ and /faq/mrz-scanner/license/. Those
+      # product-scoped URLs are the ones linked from the site and correctly
+      # highlighted in the sidebar; this bare path has no product context
+      # for the sidebar to highlight, so keep it out of the sitemap.
+      path: "license"
+    values:
+      sitemap: false
+  - scope:
       path: "barcode-reader/mobile/capabilities"
     values:
       highlightMenu: "/faq/barcode-reader/mobile/index.html#capabilities"


### PR DESCRIPTION
## Summary
`license/*.md` is shared content that gets duplicated at build time under `/faq/barcode-reader/license/` and `/faq/mrz-scanner/license/`, each with product-scoped SEO metadata (`_data/license_seo_overrides.yml`) and each correctly highlighted in that product's sidebar. Jekyll also naturally builds the content at its literal repo location, `/faq/license/*` — but that path isn't linked from anywhere on the site, and since it belongs to neither product, the sidebar can't highlight anything for it and falls back to dumping the entire unscoped DBR+MRZ tree with nothing active.

Confirmed via a headless-browser render of the test env:
- `/faq/barcode-reader/license/index.html` → sidebar correctly highlights "License" under DBR.
- `/faq/mrz-scanner/license/index.html` → sidebar correctly highlights "License" under MRZ.
- `/faq/license/index.html` (bare path) → nothing highlighted, full unscoped tree shown.

The bare path was also still listed in `sitemap.xml` on the test env, so it's crawlable despite not being linked anywhere.

## Fix
Add a `sitemap: false` scope override for `path: "license"` in `_config.yml`, using the same pattern as the existing `Hide_Tree_Page.html` exclusion. The page itself is unaffected and still builds/works fine for anyone who navigates there directly — this only keeps it out of `sitemap.xml` so it isn't crawled/indexed as an orphaned, unscoped entry point.

## Test plan
- [x] Verified locally with `jekyll build`: `/faq/license/*` entries are gone from `sitemap.xml`, while the two product-scoped duplicates (`/faq/barcode-reader/license/*`, `/faq/mrz-scanner/license/*`) remain.
- [x] Verified `_config.yml` still parses correctly (valid YAML).
- [ ] Spot-check on test env after deploy: confirm `/faq/license/*` pages still return 200 (unlinked but not broken) and no longer appear in `sitemap.xml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)